### PR TITLE
Clean orphaned OpenStackMachineTemplates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `openstackmachinetemplate_controller` to remove finalizers from old&ununsed templates.
+- Add `OpenStackMachineTemplate` controller to remove finalizers from unused templates.
 
 ## [0.1.0] - 2022-02-15
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -37,18 +37,6 @@ rules:
   resources:
   - openstackmachinetemplate
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - openstackmachinetemplate/status
-  verbs:
-  - get
-  - patch
-  - update

--- a/controllers/error.go
+++ b/controllers/error.go
@@ -1,0 +1,12 @@
+package controllers
+
+import "github.com/giantswarm/microerror"
+
+var invalidObjectError = &microerror.Error{
+	Kind: "invalidObjectError",
+}
+
+// IsInvalidObject asserts invalidObjectError.
+func IsInvalidObject(err error) bool {
+	return microerror.Cause(err) == invalidObjectError
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/gophercloud/gophercloud v0.16.0
 	github.com/prometheus/client_golang v1.12.0 // indirect
+	go.uber.org/zap v1.19.0
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2

--- a/helm/cluster-api-cleaner-openstack/templates/deployment.yaml
+++ b/helm/cluster-api-cleaner-openstack/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         args:
         - --enable-leader-election
         - --management-cluster={{ .Values.managementCluster }}
+        - -v={{ .Values.logLevel }}
         resources:
           requests:
             cpu: 100m

--- a/helm/cluster-api-cleaner-openstack/templates/rbac.yaml
+++ b/helm/cluster-api-cleaner-openstack/templates/rbac.yaml
@@ -7,20 +7,26 @@ metadata:
 rules:
 - apiGroups:
   - cluster.x-k8s.io
-  - infrastructure.cluster.x-k8s.io
   resources:
-  - openstackclusters
-  - openstackmachinetemplates
-  - openstackclusters/status
   - clusters
   - clusters/status
   - machinesets
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
+- apiGroups:
+    - infrastructure.cluster.x-k8s.io
+  resources:
+    - openstackclusters
+    - openstackmachinetemplates
+    - openstackclusters/status
+  verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/helm/cluster-api-cleaner-openstack/values.yaml
+++ b/helm/cluster-api-cleaner-openstack/values.yaml
@@ -7,6 +7,8 @@ image:
 registry:
   domain: docker.io
 
+logLevel: 0
+
 pod:
   user:
     id: 1000

--- a/main.go
+++ b/main.go
@@ -22,14 +22,14 @@ import (
 	"fmt"
 	"os"
 
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	capo "sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha4"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/giantswarm/microerror"
 
@@ -64,6 +64,7 @@ func mainE(ctx context.Context) error {
 		enableLeaderElection bool
 		managementCluster    string
 		metricsAddr          string
+		logLevel             int
 	)
 
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
@@ -73,9 +74,11 @@ func mainE(ctx context.Context) error {
 
 	flag.StringVar(&managementCluster, "management-cluster", "", "Name of the management cluster.")
 
+	flag.IntVar(&logLevel, "v", 0, "Number for the log level verbosity")
+
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	ctrl.SetLogger(zap.New(zap.Level(zapcore.Level(-logLevel))))
 
 	config, err := ctrl.GetConfig()
 	if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/860 

Complementary of https://github.com/giantswarm/cluster-openstack/pull/71

In cluster-openstack, we create OpenStackMachineTemplate
with finalizers to prevent their deletion by helm. Since
CAPI controllers cannot handle rollouts when old templates
are missing. This PR adapts the operator in a way that it
removes finalizers from OpenStackMachineTemplate objects
when there is no machineset that gives reference to that
template.

Note that machineset objects are not deleted by machinedeployment
controller just after rollout. revisionHistoryLimit is 1 by default.
It means an unused machineset is deleted by machinedeployment controller
after the next upgrade and it triggers deletion of OpenStackMachineTemplate
deletion.

## Checklist

- [x] Update changelog in CHANGELOG.md.
