### PR TITLE
Requeue OpenStackClusters when deletion is in-progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Requeue OpenStackClusters when deletion is in-progress.
+
 ## [0.2.0] - 2022-03-22
 
 ### Added

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -8,5 +8,5 @@ import (
 )
 
 type Cleaner interface {
-	Clean(ctx context.Context, log logr.Logger, oc *capo.OpenStackCluster, clusterTag string) error
+	Clean(ctx context.Context, log logr.Logger, oc *capo.OpenStackCluster, clusterTag string) (requeue bool, err error)
 }

--- a/pkg/cleaner/loadbalancers.go
+++ b/pkg/cleaner/loadbalancers.go
@@ -15,6 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/cluster-api-cleaner-openstack/pkg/key"
 )
 
 type LoadBalancerCleaner struct {
@@ -28,38 +30,45 @@ func NewLoadBalancerCleaner(cli client.Client) *LoadBalancerCleaner {
 // force implementing Cleaner interface
 var _ Cleaner = &LoadBalancerCleaner{}
 
-func (lbc *LoadBalancerCleaner) Clean(ctx context.Context, log logr.Logger, oc *capo.OpenStackCluster, clusterTag string) error {
+func (lbc *LoadBalancerCleaner) Clean(ctx context.Context, log logr.Logger, oc *capo.OpenStackCluster, clusterTag string) (bool, error) {
 	log = log.WithName("LoadBalancerCleaner")
 
 	providerClient, opts, err := provider.NewClientFromCluster(ctx, lbc.cli, oc)
 	if err != nil {
-		return microerror.Mask(err)
+		return true, microerror.Mask(err)
 	}
 
 	loadbalancerClient, err := openstack.NewLoadBalancerV2(providerClient, gophercloud.EndpointOpts{
 		Region: opts.RegionName,
 	})
 	if err != nil {
-		return microerror.Mask(err)
+		return true, microerror.Mask(err)
 	}
 
 	allPages, err := loadbalancers.List(loadbalancerClient, loadbalancers.ListOpts{}).AllPages()
 	if err != nil {
-		return microerror.Mask(err)
+		return true, microerror.Mask(err)
 	}
 
 	lbList, err := loadbalancers.ExtractLoadBalancers(allPages)
 	if err != nil {
-		return microerror.Mask(err)
+		return true, microerror.Mask(err)
 	}
 
 	networkingService, err := networking.NewService(providerClient, opts, log)
 	if err != nil {
-		return microerror.Mask(err)
+		return true, microerror.Mask(err)
 	}
 
+	requeue := false
 	for _, lb := range lbList {
 		if !mustBeDeleted(lb, clusterTag) {
+			continue
+		}
+
+		if lb.ProvisioningStatus == key.LoadBalancerProvisioningStatusPendingDelete {
+			log.V(1).Info("Loadbalancer is being deleted", "id", lb.ID)
+			requeue = true
 			continue
 		}
 
@@ -70,26 +79,33 @@ func (lbc *LoadBalancerCleaner) Clean(ctx context.Context, log logr.Logger, oc *
 		if lb.VipPortID != "" {
 			fip, err := networkingService.GetFloatingIPByPortID(lb.VipPortID)
 			if err != nil {
-				return microerror.Mask(err)
+				return true, microerror.Mask(err)
 			}
 
 			if fip != nil && fip.FloatingIP != "" {
 				log.Info("Cleaning floating IP", "ip", fip.FloatingIP, "loadbalancer", lb.ID)
 				err = lbc.cleanFloatingIP(networkingService, oc, fip)
 				if err != nil {
-					return microerror.Mask(err)
+					return true, microerror.Mask(err)
 				}
 			}
 		}
 
-		log.Info("Cleaning load balancer", "id", lb.ID)
+		log.Info("Cleaning load balancer", "id", lb.ID, "status", lb.ProvisioningStatus)
 		err = loadbalancers.Delete(loadbalancerClient, lb.ID, deleteOpts).ExtractErr()
 		if err != nil {
-			return microerror.Mask(err)
+			return true, microerror.Mask(err)
+		} else {
+			requeue = true
 		}
 	}
 
-	return nil
+	log.V(1).Info("", "Requeue", requeue)
+	if requeue {
+		return true, nil
+	} else {
+		return false, nil
+	}
 }
 
 func (lbc *LoadBalancerCleaner) cleanFloatingIP(ns *networking.Service, oc *capo.OpenStackCluster, fip *floatingips.FloatingIP) error {

--- a/pkg/cleaner/loadbalancers.go
+++ b/pkg/cleaner/loadbalancers.go
@@ -66,8 +66,10 @@ func (lbc *LoadBalancerCleaner) Clean(ctx context.Context, log logr.Logger, oc *
 			continue
 		}
 
+		log.Info("Cleaning load balancer", "id", lb.ID, "status", lb.ProvisioningStatus)
+
 		if lb.ProvisioningStatus == key.LoadBalancerProvisioningStatusPendingDelete {
-			log.V(1).Info("Loadbalancer is being deleted", "id", lb.ID)
+			log.V(1).Info("Loadbalancer deletion already triggered", "id", lb.ID)
 			requeue = true
 			continue
 		}
@@ -91,7 +93,6 @@ func (lbc *LoadBalancerCleaner) Clean(ctx context.Context, log logr.Logger, oc *
 			}
 		}
 
-		log.Info("Cleaning load balancer", "id", lb.ID, "status", lb.ProvisioningStatus)
 		err = loadbalancers.Delete(loadbalancerClient, lb.ID, deleteOpts).ExtractErr()
 		if err != nil {
 			return true, microerror.Mask(err)

--- a/pkg/cleaner/volumes.go
+++ b/pkg/cleaner/volumes.go
@@ -61,7 +61,7 @@ func (vc *VolumeCleaner) Clean(ctx context.Context, log logr.Logger, oc *capo.Op
 	for _, volume := range volumeList {
 		log.Info("Cleaning volume.", "id", volume.ID, "status", volume.Status)
 		if volume.Status == key.VolumeStatusDeleting {
-			log.V(1).Info("Volume is being deleted", "id", volume.ID)
+			log.V(1).Info("Volume deletion already triggered", "id", volume.ID)
 			requeue = true
 			continue
 		}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -6,6 +6,7 @@ const (
 	CleanerFinalizerName = "cluster-api-cleaner-openstack.finalizers.giantswarm.io"
 	CinderCsiTag         = "cinder.csi.openstack.org/cluster"
 
-	LoadBalancerProvisioningStatusPendingDelete = "PENDING_DELETE"
-	VolumeStatusDeleting                        = "deleting"
+	LoadBalancerProvisioningStatusActive = "ACTIVE"
+	LoadBalancerProvisioningStatusError  = "ERROR"
+	VolumeStatusDeleting                 = "deleting"
 )

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -5,4 +5,7 @@ const (
 	CapiClusterLabelKey  = "cluster.x-k8s.io/cluster-name"
 	CleanerFinalizerName = "cluster-api-cleaner-openstack.finalizers.giantswarm.io"
 	CinderCsiTag         = "cinder.csi.openstack.org/cluster"
+
+	LoadBalancerProvisioningStatusPendingDelete = "PENDING_DELETE"
+	VolumeStatusDeleting                        = "deleting"
 )


### PR DESCRIPTION
When `loadbalancers.Delete` and `volumes.Delete` returns, those openstack resources are not deleted. OpenStack changes the statuses of objects and starts the deletion process. We should continue reconciliation until they are really deleted. Also, Openstack API gives errors when we try to delete resources when they are in deleting status. We should be robust for this situation too.

## Checklist

- [x] Update changelog in CHANGELOG.md.
