### PR TITLE
Increase memory limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Increase memory limit from `80Mi` to `200Mi` since we observed `OOMKilled` in production.
+
 ## [0.5.0] - 2022-06-27
 
 ## Removed

--- a/helm/cluster-api-cleaner-openstack/templates/deployment.yaml
+++ b/helm/cluster-api-cleaner-openstack/templates/deployment.yaml
@@ -39,5 +39,5 @@ spec:
             memory: 50Mi
           limits:
             cpu: 100m
-            memory: 80Mi
+            memory: 200Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
While cleaning WC resources (load balancer and volumes),  this operator sends some requests to OpenStack API and fetches some objects. In production environments, there are so many objects in OpenStack API and we observe `OOMKilled` errors.  We need to increase the limit.

Data from the prod clusters while deleting 2 clusters at the same time.
![Screen Shot 2022-08-11 at 15 27 34](https://user-images.githubusercontent.com/6574144/184133350-59b23195-1abb-4dd3-8814-1fa8bc0b335f.png)


## Checklist

- [x] Update changelog in CHANGELOG.md.
